### PR TITLE
Redo relative font sizes in perfect fourth proportions

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -21,9 +21,19 @@ p {
 a {
   text-decoration: none;
 }
+button {
+  border: none;
+  background-color: #fd6632;
+  color: white;
+  padding: 1em 1.5em;
+  font-size: 1em;
+}
+button:hover {
+  cursor: pointer;
+}
 article h1, .services h3, .about h2, .clients h2 {
   position: relative;
-  font-size: 160%;
+  font-size: 1.777em;
   overflow: hidden;
   text-align: center;
   letter-spacing: 0.1em;
@@ -54,6 +64,9 @@ article h1, .services h3, .about h2, .clients h2 {
   }
   article {
     padding: 2em 8%;
+  }
+  article h1, .services h3, .about h2, .clients h2 {
+    font-size: 2.369em;
   }
 }
 /*&&&&&&&&&&&&&&&&&&&&&&&&&&
@@ -154,7 +167,7 @@ header {
   height: 1.5em;
   border-radius: 50%;
   background-color: #fd6632;
-  font-size: 320%;
+  font-size: 3.157em;
   color: #fff;
   line-height: 1.5;
 }
@@ -177,7 +190,7 @@ header h1 {
   }
   .headertext {
     max-width: 28em;
-    font-size: 1.5em;
+    font-size: 1.618em;
   }
 }
 /*&&&&&&&&&&&&&&&&
@@ -192,9 +205,12 @@ header h1 {
   font-weight: 100;
 }
 .services h2, .services h3 {
-  font-size: 130%;
+  font-size: 1.777em;
   margin-bottom: .5em;
   letter-spacing: 0.05em;
+}
+.services h3 {
+  margin: 0 10%;
 }
 .services p {
   margin: 2em 0 1em 0;
@@ -230,7 +246,7 @@ header h1 {
   text-align: center;
 }
 .strengths figcaption {
-  font-size: 80%;
+  font-size: 0.75em;
   line-height: 1.5;
   letter-spacing: 0.02em;
   width: 80%;
@@ -242,7 +258,7 @@ header h1 {
   height: 2em;
   border-radius: 50%;
   background-color: #fff;
-  font-size: 400%;
+  font-size: 3.157em;
   color: #fd6632;
   line-height: 2;
 }
@@ -261,28 +277,18 @@ th, td {
   color: #414141;
   padding: 1em;
   border-top: 1px solid #fd6632;
-  font-size: 65%;
+  font-size: 0.75em;
 }
 th strong {
-  font-size: 150%;
+  font-size: 1.333em;
 }
 .price {
   color: #fd6632;
 }
 .signup {
   background-color: #be4c25;
-  padding: 1.5em 5em;
+  padding: 1.5em 4.157em;
   border-top: 1px solid #fd6632;
-}
-button {
-  border: none;
-  background-color: #fd6632;
-  color: white;
-  padding: 1em 1.5em;
-  font-size: 100%;
-}
-button:hover {
-  cursor: pointer;
 }
 /* Services article desktop layout */
 @media screen and (min-width: 50em) {
@@ -296,6 +302,9 @@ button:hover {
   .strengths {
     display: inline-block;
     width: 32%;
+  }
+  .strengths figcaption {
+    font-size: 0.9em;
   }
   .price-tables h3 {
     margin-bottom: 0.5em;
@@ -369,7 +378,7 @@ button:hover {
   height: 2em;
   border-radius: 50%;
   background-color: #fd6632;
-  font-size: 200%;
+  font-size: 2.369em;
   color: #fff;
   line-height: 2;
   opacity: 0;
@@ -465,8 +474,8 @@ button:hover {
   font-weight: 100;
 }
 .about h2 {
-  font-size: 130%;
-  margin-bottom: 1em;
+  font-size: 1.777em;
+  margin: 0 10% 1em 10%;
   letter-spacing: 0.05em;
 }
 .about h3 {
@@ -532,9 +541,9 @@ $$$$$$$$$$$$$$$$$$$*/
   font-weight: normal;
 }
 .team h2 {
-  font-size: 130%;
+  font-size: 1.777em;
   color: #000;
-  margin: 0em 3em 1em 3em;
+  margin: 0em 10% 1em 10%;
 }
 .team h3 {
   font-weight: bold;
@@ -543,7 +552,7 @@ $$$$$$$$$$$$$$$$$$$*/
   margin-top: 2em;
 }
 .team h4 {
-  font-size: 75%;
+  font-size: 0.75em;
   padding: 0.5em 0 1.5em 0;
   letter-spacing: 0.05em;
 }
@@ -597,13 +606,14 @@ $$$$$$$$$$$$$$$$$$$*/
   width: 1em;
   height: 1em;
   border-radius: 50%;
-  font-size: 300%;
+  font-size: 1.777em;
   font-weight: 600;
   color: #fff;
   background-color: rgb(124,131,135);
 }
 @media screen and (min-width: 50em) {
   .icon-go-right:before, .icon-go-left:before {
+    font-size: 3.157em;
     background-color: #fd6632;
   }
 }
@@ -741,7 +751,7 @@ $$$$$$$$$$$$$$$$$$$*/
   color: #fd6632;
   background-color: white;
   margin-bottom: 2em;
-  font-size: 0.7em;
+  font-size: 0.75em;
 }
 /* Location map */
 .contactmap figure {
@@ -758,7 +768,10 @@ $$$$$$$$$$$$$$$$$$$*/
   margin-top: 1.5em;
   padding-left: 0.8em;
   display: inline-block;
-  font-size: 80%;
+  font-size: 0.75em;
+}
+.contactmap a {
+  color: #fff; /* phone number on mobile */
 }
 .contactmap img {
   width: 100%;
@@ -804,7 +817,7 @@ $$$$$$$$$$$$$$$$$$$*/
     margin-top: 1.5em;
     padding-left: 0.5em;
     display: inline-block;
-    font-size: 80%;
+    font-size: 0.75em;
   }
 }
 /*$$$$$$$$$$$$$$$$$$
@@ -814,7 +827,7 @@ $$$$$$$$$$$$$$$$$$$*/
 $$$$$$$$$$$$$$$$$$$*/
 footer {
   text-align: center;
-  padding: 3em 0;
+  padding: 3em 1em;
 }
 footer a {
   color: #fd6632;


### PR DESCRIPTION
Used http://type-scale.com/ to find values for "perfect fourth" proportions. Body text is 1em, one size smaller (figcaptions, map address etc) is 0.75 em, and the larger sizes are 1.333em (h3), 1.777em (h2), 2.369em (h1), and 3.157em (large icons).  A few non-proportional values are used in the media queries to fit the desktop format size. 
