### PR TITLE
Added import tag to main.scss to include header_deco file in compilation

### DIFF
--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -2,6 +2,8 @@
 
 @import "icon-styles";
 
+@import "header_deco";
+
 /*&&&&&&&&&&&&&&&&&&&&&&&&&&
 
     General styles


### PR DESCRIPTION
Added `@import "header_deco";` to `main.scss`.  Deleted mistake file called `_header_deco` that lacked file extension.
