### PR TITLE
Prep main and global scss for future work

### DIFF
--- a/public/sass/_global.scss
+++ b/public/sass/_global.scss
@@ -1,19 +1,3 @@
-@import "reset";
-@import "global";
-
-@import "icon-styles";
-@import "nav";
-@import "button";
-@import "header";
-@import "price-tables";
-@import "social_link_styles";
-@import "gallery-items";
-@import "header_deco";
-@import "figure";
-@import "slider";
-@import "notch";
-
-
 /*&&&&&&&&&&&&&&&&&&&&&&&&&&
     General styles
 &&&&&&&&&&&&&&&&&&&&&&&&&&&*/


### PR DESCRIPTION
Removed all general CSS from main.scss into _global.scss. Left comments to help with loose ends (i.e. figures, contact map, form, progress bars, portfolio image).
