### PR TITLE
Fix Safari flexbox bug in Portfolio section

### DIFF
--- a/public/sass/_gallery-items.scss
+++ b/public/sass/_gallery-items.scss
@@ -1,6 +1,7 @@
 .gallery-flex {
   @media screen and (min-width: 50em) {
     display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
+    display: -webkit-flex;     /* Safari needs this one */
     display: -ms-flexbox;      /* TWEENER - IE 10 */
     display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
     -webkit-flex-direction: row; /*safari also required these to have -webkit*/


### PR DESCRIPTION
Portfolio section flexbox was broken in Safari on desktop; added `display: -webkit-flex;` to the flex container to fix it.
